### PR TITLE
Re-enable tab and category pages

### DIFF
--- a/_posts/2025-01-09-visualizing-literature-with-open-source-deep-learning-models.md
+++ b/_posts/2025-01-09-visualizing-literature-with-open-source-deep-learning-models.md
@@ -1,7 +1,7 @@
 ---
 title: "Visualizing Literature With Open-Source Deep Learning Models"
 date: 2025-01-09 17:49:30 +300
-categories: [Applied Gen AI]
+categories: [Fun With Deep Learning]
 tags: [diffusers, transformers, literature, python]     # TAG names should always be lowercase
 ---
 A Practical Guide to the Recently Impossible

--- a/_tabs/categories.md
+++ b/_tabs/categories.md
@@ -1,0 +1,5 @@
+---
+layout: categories
+icon: fas fa-stream
+order: 1
+---

--- a/_tabs/tags.md
+++ b/_tabs/tags.md
@@ -1,0 +1,5 @@
+---
+layout: tags
+icon: fas fa-tags
+order: 2
+---


### PR DESCRIPTION
This PR:
* Re-enables tab and category pages so that internal links don't break.
* :speak_no_evil: It also renames the category of the first article